### PR TITLE
Fix the link for Emaildrop

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A curated list of awesome internet services that normally you would have to regi
 * [Shick](https://shick.me) - Instant normal chat rooms.
 * [Yap](https://yap.chat/) - Instant ephemeral chat rooms in which even the messages are ephemeral, for friends.
 * [Jitsi](https://meet.jit.si/) offers instant video chat rooms over webRTC. [room.sh](https://room.sh/) goes one step further and offers that plus collaborative code editors, document editors and drawable whiteboards.
-* [Mailinator](https://www.mailinator.com/), [Maildrop](https://maildrop.cc/), [Nada](https://getnada.com/) and other disposable email address services allow you to use one or multiple email addresses without registering (everything is public). [Emaildrop](https://www.emaildrop.io/v1) has even a public API!
+* [Mailinator](https://www.mailinator.com/), [Maildrop](https://maildrop.cc/), [Nada](https://getnada.com/) and other disposable email address services allow you to use one or multiple email addresses without registering (everything is public). [Emaildrop](https://www.emaildrop.io/) has even a public API!
 * [Kill the Newsletter!](https://kill-the-newsletter.com/) - Convert email newsletters into Atom feeds
 
 ## Development Tools


### PR DESCRIPTION
Remove the trailing `/v1` from the Emaildrop link

https://www.emaildrop.io is the new working link